### PR TITLE
Update optimizer.class.php

### DIFF
--- a/modules/optimizer/optimizer.class.php
+++ b/modules/optimizer/optimizer.class.php
@@ -421,7 +421,7 @@ class optimizer extends module
             $pvalue = SQLSelectOne($sqlQuery);
 
 
-            if ($pvalue['OTITLE'] != '') {
+            if ($pvalue['CTITLE'] != '') {
                 $key = $pvalue['OTITLE'] . '.' . $pvalue['PTITLE'];
 
                 $rule = '';

--- a/modules/optimizer/optimizer.class.php
+++ b/modules/optimizer/optimizer.class.php
@@ -421,17 +421,19 @@ class optimizer extends module
             $pvalue = SQLSelectOne($sqlQuery);
 
 
-            if ($pvalue['CTITLE'] != '') {
-                $key = $pvalue['CTITLE'] . '.' . $pvalue['PTITLE'];
+            if ($pvalue['OTITLE'] != '') {
+                $key = $pvalue['OTITLE'] . '.' . $pvalue['PTITLE'];
+
                 $rule = '';
 
                 if ($rules[$key]) {
                     $rule = $rules[$key];
-                } elseif ($rules[$pvalue['OTITLE'] . '.' . $pvalue['PTITLE']]) {
-                    $rule = $rules[$pvalue['OTITLE'] . '.' . $pvalue['PTITLE']];
+                } elseif ($rules[$pvalue['CTITLE'] . '.' . $pvalue['PTITLE']]) {
+                    $key = $pvalue['CTITLE'] . '.' . $pvalue['PTITLE'];
                 } elseif ($rules[$pvalue['PTITLE']]) {
-                    $rule = $rules[$pvalue['PTITLE']];
+                    $key = $pvalue['PTITLE'];
                 }
+                $rule = $rules[$key];
 
                 if ($rule) {
                     //processing


### PR DESCRIPTION
Мне кажется логичным, отдавать предпочтения сначала записям указывающим на объект.класс, а лишь потом, если таковых нет, то на класс.свойство и потом на просто свойство.
До этого исправления при наличии SMotions: Motion06.status и SMotions: *.status предпочтение отдавалось второму.
При этом, если запускать оптимизацию свойств вручную, после анализа, то оптимизируется по той же логике, что и у меня.
Запутанно как-то сформулировал :(